### PR TITLE
increase robustness of inverter reads

### DIFF
--- a/server/src/main/index.ts
+++ b/server/src/main/index.ts
@@ -23,8 +23,8 @@ function createReadInterval() {
     setTimeout(fxn, INVERTER_READ_INTERVAL)
   }
 
-  console.log(new Date(), 'Running initial data retrieval')
-  setImmediate(fxn)
+  console.log(new Date(), 'Queuing initial data retrieval')
+  setTimeout(fxn, INVERTER_READ_INTERVAL)
 }
 
 async function bootstrap() {


### PR DESCRIPTION
- deferring initial data read
- timing out inverter read operations after 15 seconds
- requiring callers of readRegisters to pre-invoke `connect`, otherwise an error will be thrown